### PR TITLE
Webpack chores

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -224,7 +224,7 @@ module.exports = env => {
                     test: /\.svelte$/,
                     exclude: /node_modules/,
                     use: [
-                        { 
+                        {
                             loader: 'svelte-loader',
                             options: {
                                 preprocess: svelteNativePreprocessor()

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 const { join, relative, resolve, sep } = require("path");
 
 const webpack = require("webpack");

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -209,6 +209,10 @@ module.exports = env => {
                 },
 
                 {
+                    test: /\.mjs$/,
+                    type: 'javascript/auto',
+                },
+                {
                     test: /\.ts$/,
                     use: {
                         loader: "ts-loader",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -90,7 +90,7 @@ module.exports = env => {
             hashSalt
         },
         resolve: {
-            extensions: [".ts", ".js", ".scss", ".css"],
+            extensions: [".ts", ".js", ".svelte", ".scss", ".css"],
             // Resolve {N} system modules from tns-core-modules
             modules: [
                 resolve(__dirname, "node_modules/tns-core-modules"),


### PR DESCRIPTION
Small maintenance of webpack.config.js file:

- remove a trailing whitespace (we should put prettier in this and be done with formatting issues)

- add eslint env to avoid lots of "undefined variable" warnings

- add `.svelte` to import extensions

- last but not least, add a `.mjs` rule to fix crash when importing from svelte