### PR TITLE
use latest svelte-loader-hot with Svelte 3.16+ and TNS 6.2+ support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5166,6 +5166,25 @@
         "svelte-hmr": "github:halfnelson/svelte-hmr#patch-1"
       }
     },
+    "svelte-loader-hot": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/svelte-loader-hot/-/svelte-loader-hot-0.1.1.tgz",
+      "integrity": "sha512-Tzbh98Q0UBZS2ts8T2+V0dES0dlbPhzj33VY3Owj+kRtqvHBaQBJ+zuOtrk1T4X60Qi1LasJZtAsHue+JVBC8w==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "svelte-dev-helper": "^1.1.9",
+        "svelte-hmr": "^0.1.3"
+      },
+      "dependencies": {
+        "svelte-hmr": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.1.3.tgz",
+          "integrity": "sha512-M/r93UeGKXZ5VrlzAmLT3V+uI5kJ5UlBXdv/NjsCm+aFUK1dL0YfXAHljdq2vD16TReqrD86JN/ycq72kRpABg==",
+          "dev": true
+        }
+      }
+    },
     "svelte-native": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/svelte-native/-/svelte-native-0.7.2.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "nativescript-dev-webpack": "1.3.0",
     "svelte": "~3.16.4",
     "svelte-loader": "github:halfnelson/svelte-loader#native",
+    "svelte-loader-hot": "^0.1.1",
     "svelte-native-preprocessor": "^0.1.4",
     "typescript": "3.6.2"
   },


### PR DESCRIPTION
I finally got some time to untrash the HMR test suite, and publish a new version of `svelte-hot-loader` with your TNS fix, and restored support for Svelte 3.16+.