### PR TITLE
Suppressing warnings raised by Svelte for A11y

### DIFF
--- a/svelte-native.webpack.config.js
+++ b/svelte-native.webpack.config.js
@@ -18,6 +18,11 @@ module.exports = env => {
                     hotOptions: {
                         injectCss: false,
                         native: true
+                    },
+                    onwarn: (warning, onwarn) => {
+                        if (!/A11y:/.test(warning.message)) {
+                            onwarn(warning);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
resolves #177

In a recent update, Svelte has added an HTML validation check for the a11y rule that a label should be associated with a form element. This was done as part of sveltejs/svelte#820

The most obvious example of this is that <Label> elements now reult in a warning as they look like HTML labels. There may well be others. This behaviour can be seen in the hello world REPL example https://svelte-native.technology/repl?version=3.24.1&example=hello-world, complaining about the labels defined on lines 5 and 7.
